### PR TITLE
Added theme toggle to switch between system/dark/light

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "lucide-react": "^0.268.0",
         "next": "13.4.19",
         "next-auth": "^4.23.1",
+        "next-themes": "^0.2.1",
         "postcss": "8.4.28",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -3444,6 +3445,16 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -7220,6 +7231,12 @@
         "preact-render-to-string": "^5.1.19",
         "uuid": "^8.3.2"
       }
+    },
+    "next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "requires": {}
     },
     "node-releases": {
       "version": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lucide-react": "^0.268.0",
     "next": "13.4.19",
     "next-auth": "^4.23.1",
+    "next-themes": "^0.2.1",
     "postcss": "8.4.28",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import Navbar from "@/components/navbar";
+import Providers from "@/components/providers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -20,8 +21,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={cn(inter.className, "antialiased min-h-screen pt-16")}>
-        <Navbar />
-        {children}
+        <Providers>
+          <Navbar />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import SignInButton from "@/components/sign-in-button";
 import UserAccountDropdown from "@/components/user-account-dropdown";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 type Props = {};
 
@@ -19,11 +20,14 @@ const Navbar = async (props: Props) => {
           </p>
         </Link>
         <div className="flex items-center">
-          {session?.user ? (
-            <UserAccountDropdown user={session.user} />
-          ) : (
-            <SignInButton text="Sign In" />
-          )}
+          <ThemeToggle className="mr-4" />
+          <div className="flex items-center">
+            {session?.user ? (
+              <UserAccountDropdown user={session.user} />
+            ) : (
+              <SignInButton text="Sign In" />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,11 +1,16 @@
+"use client";
+
 import { SessionProvider } from "next-auth/react";
 
-type Props = {
-  children: React.ReactNode;
-};
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes/dist/types";
 
-const Providers = ({ children }: Props) => {
-  return <SessionProvider>{children}</SessionProvider>;
+const Providers = ({ children, ...props }: ThemeProviderProps) => {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      <SessionProvider>{children}</SessionProvider>
+    </NextThemesProvider>
+  );
 };
 
 export default Providers;

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ThemeToggle({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const { setTheme } = useTheme();
+
+  return (
+    <div className={className} {...props}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="icon">
+            <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+            <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            <span className="sr-only">Toggle theme</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setTheme("light")}>
+            Light
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme("dark")}>
+            Dark
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setTheme("system")}>
+            System
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}


### PR DESCRIPTION
Successfully set up `next-themes` for our Next.js project that's built with ShadCN and Tailwind CSS. Now users can enjoy a convenient theme toggle, shifting between system, dark, and light modes effortlessly. This should elevate the overall UX and accessibility of the app. 

Glad to see this feature up and running! 🌗🌞🌓