### PR TITLE
Added home page styling with login redirect

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,7 @@
+type Props = {};
+
+const Dashboard = (props: Props) => {
+  return <div>Dashboard</div>;
+};
+
+export default Dashboard;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,37 @@
-import { Button } from "@/components/ui/button";
+import { getAuthSession } from "@/lib/nextauth";
+import { redirect } from "next/navigation";
 
-export default function Home() {
-  return <Button>Hello World</Button>;
+import SignInButton from "@/components/sign-in-button";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default async function Home() {
+  const session = await getAuthSession();
+
+  if (session?.user) {
+    // user is logged in
+    redirect("/dashboard");
+  }
+  return (
+    <div className="absolute -translate-x-1/2 translate-y-1/2 top-1/2 left-1/2">
+      <Card className="w-[300px]">
+        <CardHeader>
+          <CardTitle>Welcome to Quizmify</CardTitle>
+          <CardDescription>
+            Quizmify is a quiz app that allows you to create and share quizzes
+            with your friends.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <SignInButton text="Sign In with Google!" />
+        </CardContent>
+      </Card>
+    </div>
+  );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
Integrated a homepage card component with ShadCN to let users Sign In with Google. If a user has an active session, they get redirected to `/dashboard` automatically.